### PR TITLE
Add support for Cordova

### DIFF
--- a/BMSFacebookAuthentication.podspec
+++ b/BMSFacebookAuthentication.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "BMSFacebookAuthentication"
-    s.version      = '2.0.0'
+    s.version      = '2.0.1'
     s.ios.deployment_target = '8.0'
     s.platform     = :ios, '8.0'
     s.requires_arc = true

--- a/BMSFacebookAuthentication.podspec
+++ b/BMSFacebookAuthentication.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "BMSFacebookAuthentication"
-    s.version      = '2.0.1'
+    s.version      = '2.0.3'
     s.ios.deployment_target = '8.0'
     s.platform     = :ios, '8.0'
     s.requires_arc = true

--- a/Source/FacebookAuthenticationManager.swift
+++ b/Source/FacebookAuthenticationManager.swift
@@ -25,7 +25,7 @@ import FBSDKLoginKit
 import BMSAnalyticsAPI
 
 #if swift(>=3.0)
-public class FacebookAuthenticationManager :NSObject,AuthenticationDelegate{
+@objc public class FacebookAuthenticationManager :NSObject,AuthenticationDelegate{
     
     private static let FACEBOOK_REALM="wl_facebookRealm";
     private static let ACCESS_TOKEN_KEY="accessToken";
@@ -113,7 +113,7 @@ public class FacebookAuthenticationManager :NSObject,AuthenticationDelegate{
     
 }
 #else
-public class FacebookAuthenticationManager :NSObject,AuthenticationDelegate{
+@objc public class FacebookAuthenticationManager :NSObject,AuthenticationDelegate{
     
     private static let FACEBOOK_REALM="wl_facebookRealm";
     private static let ACCESS_TOKEN_KEY="accessToken";


### PR DESCRIPTION
The FacebookAuthenticationManager class must be accessible in Objective-C to be supported for Cordova.
